### PR TITLE
Add glm->SSS color conversion for assign operator glm = SSS::Color

### DIFF
--- a/inc/Commons/color.hpp
+++ b/inc/Commons/color.hpp
@@ -41,6 +41,8 @@ struct SSS_COMMONS_API RGB24 {
 
     std::string to_string() const;
     operator std::string() const;
+    operator glm::vec3() const;
+
 };
 
 /** \c 32 bits (Red, Green, Blue, Alpha) color union.
@@ -80,6 +82,7 @@ struct SSS_COMMONS_API RGBA32 {
 
     std::string to_string() const;
     operator std::string() const;
+    operator glm::vec4() const;
 };
 
 
@@ -117,6 +120,8 @@ public:
 
     std::string to_string() const;
     operator std::string() const;
+    operator glm::vec4() const;
+
 
     glm::vec4 _col;
 };

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -36,6 +36,11 @@ RGB24::operator std::string() const
     return to_string();
 }
 
+RGB24::operator glm::vec3() const
+{
+    return glm::vec3(r, g, b)/255.f;
+}
+
 
 RGBA32::RGBA32(const RGBA_f& c)
 {
@@ -71,6 +76,11 @@ std::string RGBA32::to_string() const
 RGBA32::operator std::string() const
 {
     return to_string();
+}
+
+RGBA32::operator glm::vec4() const
+{
+    return glm::vec4(r, g, b, a) / 255.f;
 }
 
 // Returns a rainbow color based on the passed value.
@@ -134,6 +144,11 @@ std::string RGBA_f::to_string() const
 RGBA_f::operator std::string() const
 {
     return to_string();
+}
+
+RGBA_f::operator glm::vec4() const
+{
+    return _col;
 }
 
 RGBA_f::RGBA_f(const std::string& hex) 


### PR DESCRIPTION
Add colors conversion, possibility to assign an SSS::RGBA32, RGBA_f ou RGB24 to a glm::vec3 ou glm::vec4 object

```glm::vec4 col = RGBA_f(#FFFFFF)```
```glm::vec3 col = RGB24(#FFFFFF)```


