### PR TITLE
Add a common event enum that can be used in all modules

### DIFF
--- a/Commons.vcxproj
+++ b/Commons.vcxproj
@@ -40,6 +40,7 @@
     <ClInclude Include="inc\Commons\env.hpp" />
     <ClInclude Include="inc\Commons.hpp" />
     <ClInclude Include="inc\Commons\color.hpp" />
+    <ClInclude Include="inc\Commons\eventList.hpp" />
     <ClInclude Include="inc\Commons\pointers.hpp" />
     <ClInclude Include="inc\Commons\log.hpp" />
     <ClInclude Include="inc\Commons\Async.hpp" />

--- a/Commons.vcxproj.filters
+++ b/Commons.vcxproj.filters
@@ -64,6 +64,9 @@
     <ClInclude Include="inc\Commons\Command.hpp">
       <Filter>inc</Filter>
     </ClInclude>
+    <ClInclude Include="inc\Commons\eventList.hpp">
+      <Filter>inc</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\color.cpp">

--- a/inc/Commons/eventList.hpp
+++ b/inc/Commons/eventList.hpp
@@ -1,0 +1,28 @@
+#ifndef SSS_EVENT_LIST_HPP
+#define SSS_EVENT_LIST_HPP
+
+#include "_includes.hpp"
+
+/** @file
+ *  Defines time-related functions and classes.
+ */
+
+SSS_BEGIN;
+
+enum EventList
+{
+	Model,
+	Alpha,
+	TexOffset,
+	Content,
+	Resize,
+	Hover,
+	Leave,
+	Clicked,
+	Held,
+	LastEvent
+};
+
+SSS_END;
+
+#endif // SSS_EVENT_LIST_HPP


### PR DESCRIPTION
List of event that can be used everywhere to avoid Event ID superposition and confusion in ``Observer::_subjectUpdate(event Id)`` where the observer could subscribe to multiple classes 